### PR TITLE
Corrected typo in checking protocol type

### DIFF
--- a/app/src/main/java/net/sylvek/itracing2/receivers/CustomAction.java
+++ b/app/src/main/java/net/sylvek/itracing2/receivers/CustomAction.java
@@ -28,7 +28,7 @@ public class CustomAction extends BroadcastReceiver {
             new CallUrl<>(action).start();
         }
 
-        if (action.startsWith("http://")) {
+        if (action.startsWith("https://")) {
             new CallUrl<HttpsURLConnection>(action).start();
         }
 


### PR DESCRIPTION
A simple typo in checking protocol type results in doubled HTTP queries.