### PR TITLE
Add a new action to toggle the play/pause state of the currently running AudioManager

### DIFF
--- a/app/src/main/java/net/sylvek/itracing2/BluetoothLEService.java
+++ b/app/src/main/java/net/sylvek/itracing2/BluetoothLEService.java
@@ -26,6 +26,7 @@ import net.sylvek.itracing2.receivers.ImmediateAlert;
 import net.sylvek.itracing2.receivers.LinkBackground;
 import net.sylvek.itracing2.receivers.ToggleRingPhone;
 import net.sylvek.itracing2.receivers.ToggleVibratePhone;
+import net.sylvek.itracing2.receivers.TogglePlayPause;
 
 import java.util.HashMap;
 import java.util.UUID;
@@ -339,6 +340,12 @@ public class BluetoothLEService extends Service {
         f6.addCategory("android.intent.category.DEFAULT");
         registerReceiver(new LinkBackground(), f6);
         Log.d(TAG, "LinkBackground() - registered with: " + f6);
+
+        IntentFilter f7 = new IntentFilter();
+        f7.addAction("net.sylvek.itracing2.action.TOGGLE_PLAY_PAUSE");
+        f7.addCategory("android.intent.category.DEFAULT");
+        registerReceiver(new TogglePlayPause(), f7);
+        Log.d(TAG, "TogglePlayPause() - registered with: " + f7);
     }
 
     public void setForegroundEnabled(boolean enabled) {

--- a/app/src/main/java/net/sylvek/itracing2/receivers/TogglePlayPause.java
+++ b/app/src/main/java/net/sylvek/itracing2/receivers/TogglePlayPause.java
@@ -1,0 +1,36 @@
+package net.sylvek.itracing2.receivers;
+
+import android.app.Notification;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.media.AudioManager;
+import android.util.Log;
+import android.view.KeyEvent;
+
+import net.sylvek.itracing2.BluetoothLEService;
+
+/**
+ * Created by antocuni on 27/11/2021, copied&adapted from ToggleRingPhone
+ */
+public class TogglePlayPause extends BroadcastReceiver {
+
+    static final int NOTIFICATION_ID = 453438;
+    public static final String TAG = TogglePlayPause.class.toString();
+
+    @Override
+    public void onReceive(Context context, Intent intent)
+    {
+        if(intent.getAction().equals(BluetoothLEService.ACTION_PREFIX + "TOGGLE_PLAY_PAUSE")) {
+            Log.d(TAG,"Toggle Play/Pause");
+            AudioManager mgr = (AudioManager)context.getSystemService(Context.AUDIO_SERVICE);
+            KeyEvent key_down = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE);
+            mgr.dispatchMediaKeyEvent(key_down);
+
+            KeyEvent key_up = new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE);
+            mgr.dispatchMediaKeyEvent(key_up);
+            return;
+        }
+
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
         <item>start vibrate the phone</item>
         <item>stop vibrate the phone</item>
         <item>capture my position</item>
+        <item>toggle AudioManager Play/Pause</item>
         <item>call a url or broadcast intent action</item>
     </string-array>
     <string-array name="button_actions_values">
@@ -82,6 +83,7 @@
         <item>START_VIBRATE_PHONE</item>
         <item>STOP_VIBRATE_PHONE</item>
         <item>CAPTURE_POSITION</item>
+        <item>TOGGLE_PLAY_PAUSE</item>
         <item>CUSTOM_ACTION</item>
     </string-array>
     <string-array name="empty_array"/>


### PR DESCRIPTION
On my device (Honor 20 Lite, `MAR-LX1H`, android 10) this seems to work well with at least Amazon Music, Spreaker and "Il Post".

If we want, we could extend this feature to support all kind of audio buttons such as "next", "previous" etc, i.e. all the `KEYCODE_MEDIA_*` events listed [here](https://developer.android.com/reference/android/view/KeyEvent).
I didn't insert all of them because I didn't want to clutter the UI with an endless list of options, and also Play/Pause looks by far the most useful of them.