### PR TITLE
Make touching notification stop ringer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,7 @@ android {
     defaultConfig {
         applicationId "net.sylvek.itracing2"
         minSdkVersion 22
+        //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 29
         versionCode 84
         versionName "2.5.9"
@@ -25,6 +26,14 @@ android {
         }
     }
     buildTypes {
+        debug {
+            debuggable true
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
+            jniDebuggable true
+            renderscriptDebuggable true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,10 +40,13 @@ repositories {
 }
 
 dependencies {
-    api 'com.android.support:appcompat-v7:23.1.1'
-    api 'com.android.support:support-v13:23.1.1'
-    api 'com.android.support:design:23.1.1'
-    api 'com.android.support:support-annotations:25.1.0'
+    //noinspection GradleCompatible,GradleCompatible
+    api 'com.android.support:appcompat-v7:28.0.0'
+    //noinspection GradleCompatible
+    api 'com.android.support:support-v13:28.0.0'
+    //noinspection GradleCompatible
+    api 'com.android.support:design:28.0.0'
+    api 'com.android.support:support-annotations:28.0.0'
     api 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.1.0'
 
     testImplementation 'junit:junit:4.12'

--- a/app/src/main/java/net/sylvek/itracing2/BluetoothLEService.java
+++ b/app/src/main/java/net/sylvek/itracing2/BluetoothLEService.java
@@ -303,6 +303,7 @@ public class BluetoothLEService extends Service {
     private void registerReceivers() {
         IntentFilter f1 = new IntentFilter();
         f1.addAction("net.sylvek.itracing2.action.CAPTURE_POSITION");
+        f1.addAction("net.sylvek.itracing2.action.GOT_LOCATION");
         f1.addCategory("android.intent.category.DEFAULT");
         registerReceiver(new CapturePosition(), f1);
         Log.d(TAG, "CapturePosition() - registered with: " + f1);
@@ -370,10 +371,12 @@ public class BluetoothLEService extends Service {
     private String getNotificationChannel(NotificationManager notificationManager) {
         String channelId = "channel-itracing2";
         String channelName = getResources().getString(R.string.app_name);
-        NotificationChannel channel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH);
-        channel.setImportance(NotificationManager.IMPORTANCE_NONE);
-        channel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
-        notificationManager.createNotificationChannel(channel);
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            NotificationChannel channel =
+                    new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_NONE);
+            channel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
+            notificationManager.createNotificationChannel(channel);
+        }
         return channelId;
     }
 

--- a/app/src/main/java/net/sylvek/itracing2/receivers/CapturePosition.java
+++ b/app/src/main/java/net/sylvek/itracing2/receivers/CapturePosition.java
@@ -5,6 +5,7 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -13,72 +14,99 @@ import android.location.Location;
 import android.location.LocationManager;
 import android.net.Uri;
 import android.support.v4.app.ActivityCompat;
+import android.util.Log;
 
 import net.sylvek.itracing2.R;
 import net.sylvek.itracing2.database.Devices;
 import net.sylvek.itracing2.database.Events;
 
+import java.util.List;
+import java.util.Objects;
+
 /**
  * Created by sylvek on 12/06/2015.
  */
 public class CapturePosition extends BroadcastReceiver {
-
-    static final Criteria criteria = new Criteria();
+    private static Intent callback = new Intent();
 
     static final int NOTIFICATION_ID = 453436;
 
-    static final long MAX_AGE = 10000; // 10 seconds
     public static final String NAME = "position";
+    public static final String TAG = CapturePosition.class.toString();
+    static final String CALLBACKACTION = "net.sylvek.itracing2.action.GOT_LOCATION";
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        // because some customers don't like Google Play Services…
-        Location bestLocation = null;
-        final LocationManager locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-        assert locationManager != null;
-        for (final String provider : locationManager.getAllProviders()) {
+        final String action = intent.getAction();
+        final String name = intent.getStringExtra(Devices.NAME);
+        final String address = intent.getStringExtra(Devices.ADDRESS);
+        final LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+        callback.setComponent(ComponentName.unflattenFromString("net.sylvek.itracing2.receivers.CapturePosition"));
+        callback.setAction(CALLBACKACTION);
+        callback.putExtra(Devices.NAME, name);
+        callback.putExtra(Devices.ADDRESS, address);
+        PendingIntent pi = PendingIntent.getBroadcast(
+                context, 0, callback,
+                PendingIntent.FLAG_UPDATE_CURRENT);
+        if (Objects.equals(action, "net.sylvek.itracing2.action.CAPTURE_POSITION")) {
+            Log.d(TAG, "Capture position for " + name);
             if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                // TODO: Consider calling
-                //    ActivityCompat#requestPermissions
-                // here to request the missing permissions, and then overriding
-                //   public void onRequestPermissionsResult(int requestCode, String[] permissions,
-                //                                          int[] grantResults)
-                // to handle the case where the user grants the permission. See the documentation
-                // for ActivityCompat#requestPermissions for more details.
-                return;
+                // Location permission should be requested
+                // in the UI when user checks "capture my position"
+                // Hard to do because the logic is buried
+                // inside a MultiSelectListPreference.
             }
-            final Location location = locationManager.getLastKnownLocation(provider);
-            final long now = System.currentTimeMillis();
-            if (location != null
-                    && (bestLocation == null || location.getTime() > bestLocation.getTime())
-                    && location.getTime() > now - MAX_AGE) {
-                bestLocation = location;
+            List<String> ls = lm.getProviders(true);
+            try {
+                if (ls.contains("gps"))
+                {
+                    /* If GPS is available use GPS only. Other providers need
+                     * a Google server which has privacy and security issues.
+                     * Also the Google server relies on Google's list of locations
+                     * of cell towers and Wi-Fi hotspots, which are privately
+                     *  owned and can be moved, so Google's list can be out of date.
+                     */
+                    Log.d(TAG, "requestLocationUpdates from gps");
+                    lm.requestLocationUpdates(
+                            "gps", 0, 0, pi);
+                }
+                else
+                {
+                    // If we don't have GPS,
+                    // we use the best that the device can give us.
+                    Criteria cr = new Criteria();
+                    cr.setAccuracy(Criteria.ACCURACY_FINE);
+                    Log.d(TAG, "no gps, requestLocationUpdates from best available");
+                    lm.requestLocationUpdates(0, 0, cr, pi);
+                }
+            } catch (SecurityException e) {
+                Events.insert(context, "No location permission", address, "Please Allow Location permission in Settings");
+                Log.d(TAG, "No location permission");
             }
-        }
-
-        if (bestLocation == null) {
-            final PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-            locationManager.requestSingleUpdate(criteria, pendingIntent);
-        }
-
-        if (bestLocation != null) {
-            NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-            final String position = bestLocation.getLatitude() + "," + bestLocation.getLongitude();
-            final Intent mapIntent = getMapIntent(position);
-
-            final Notification notification = new Notification.Builder(context)
-                    .setChannelId("channel-itracing2")
-                    .setContentText(context.getString(R.string.display_last_position))
-                    .setContentTitle(context.getString(R.string.app_name))
-                    .setSmallIcon(R.drawable.ic_launcher)
-                    .setAutoCancel(false)
-                    .setContentIntent(PendingIntent.getActivity(context, 0, mapIntent, PendingIntent.FLAG_UPDATE_CURRENT))
-                    .build();
-            assert notificationManager != null;
-            notificationManager.notify(NOTIFICATION_ID, notification);
-
-            final String address = intent.getStringExtra(Devices.ADDRESS);
-            Events.insert(context, NAME, address, position);
+        } else if (Objects.equals(action, CALLBACKACTION)) {
+            Location here = intent.getParcelableExtra(
+                    LocationManager.KEY_LOCATION_CHANGED);
+            if (here != null) {
+                lm.removeUpdates(pi);
+                final String position = here.getLatitude() + "," + here.getLongitude();
+                Log.d(TAG, "got location " + position);
+                Events.insert(context, "position", address, position);
+                final Intent mapIntent = getMapIntent(position);
+                NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                final Notification.Builder nfb = new Notification.Builder(context);
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                    nfb.setChannelId("channel-itracing2");
+                }
+                nfb.setContentText(context.getString(R.string.display_last_position))
+                   .setContentTitle(context.getString(R.string.app_name))
+                   .setSmallIcon(R.drawable.ic_launcher)
+                   .setAutoCancel(false)
+                   .setContentIntent(PendingIntent.getActivity(context, 0, mapIntent, PendingIntent.FLAG_UPDATE_CURRENT));
+                notificationManager.notify(NOTIFICATION_ID, nfb.build());
+            } else {
+                // Otherwise we don't know what to do
+                Log.d(TAG, "CapturePosition bad action " + action);
+            }
         }
     }
 

--- a/app/src/main/java/net/sylvek/itracing2/receivers/ToggleRingPhone.java
+++ b/app/src/main/java/net/sylvek/itracing2/receivers/ToggleRingPhone.java
@@ -11,6 +11,7 @@ import android.media.AudioManager;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.Uri;
+import android.os.Build;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -80,26 +81,28 @@ public class ToggleRingPhone extends BroadcastReceiver {
         final int max = audioManager.getStreamMaxVolume(AudioManager.STREAM_RING);
         audioManager.setStreamVolume(AudioManager.STREAM_RING, max, 0);
 
-        currentRingtone.setLooping(true);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            currentRingtone.setLooping(true);
+        }
         currentRingtone.play();
 //        Intent stop = new Intent(context, ToggleRingPhone.class);
         Intent stop = new Intent();
         stop.setComponent(ComponentName.unflattenFromString("net.sylvek.itracing2.receivers.ToggleRingPhone"));
         stop.setAction("net.sylvek.itracing2.action.STOP_RING_PHONE");
         PendingIntent pi = PendingIntent.getBroadcast(context, 0, stop, PendingIntent.FLAG_UPDATE_CURRENT);
-
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        final Notification notification = new Notification.Builder(context, "channel-itracing2")
-                .setChannelId("channel-itracing2")
-                .setContentText(context.getString(R.string.stop_ring))
+        final Notification.Builder nfb = new Notification.Builder(context);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            nfb.setChannelId("channel-itracing2");
+        }
+        nfb.setContentText(context.getString(R.string.stop_ring))
                 .setContentTitle(context.getString(R.string.app_name))
                 .setSmallIcon(R.drawable.ic_launcher)
                 .setAutoCancel(false)
                 .setOngoing(true)
                 .setContentIntent(pi)
-                .setDeleteIntent(pi)
-                .build();
-        notificationManager.notify(NOTIFICATION_ID, notification);
+                .setDeleteIntent(pi);
+        notificationManager.notify(NOTIFICATION_ID, nfb.build());
     }
 
     private void stopRing(Context context, Intent intent) {

--- a/app/src/main/java/net/sylvek/itracing2/receivers/ToggleRingPhone.java
+++ b/app/src/main/java/net/sylvek/itracing2/receivers/ToggleRingPhone.java
@@ -4,6 +4,7 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.media.AudioManager;
@@ -32,6 +33,7 @@ public class ToggleRingPhone extends BroadcastReceiver {
     {
         // from notification
         if(intent.getAction() == null) {
+            Log.d(TAG,"null action");
             stopRing(context, intent);
             return;
         }
@@ -55,7 +57,7 @@ public class ToggleRingPhone extends BroadcastReceiver {
             stopRing(context, intent);
             return;
         }
-
+        Log.d(TAG,"unrecognised action");
     }
 
     private void startRing(Context context, Intent intent) {
@@ -78,16 +80,24 @@ public class ToggleRingPhone extends BroadcastReceiver {
         final int max = audioManager.getStreamMaxVolume(AudioManager.STREAM_RING);
         audioManager.setStreamVolume(AudioManager.STREAM_RING, max, 0);
 
+        currentRingtone.setLooping(true);
         currentRingtone.play();
+//        Intent stop = new Intent(context, ToggleRingPhone.class);
+        Intent stop = new Intent();
+        stop.setComponent(ComponentName.unflattenFromString("net.sylvek.itracing2.receivers.ToggleRingPhone"));
+        stop.setAction("net.sylvek.itracing2.action.STOP_RING_PHONE");
+        PendingIntent pi = PendingIntent.getBroadcast(context, 0, stop, PendingIntent.FLAG_UPDATE_CURRENT);
 
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        final Notification notification = new Notification.Builder(context)
+        final Notification notification = new Notification.Builder(context, "channel-itracing2")
+                .setChannelId("channel-itracing2")
                 .setContentText(context.getString(R.string.stop_ring))
                 .setContentTitle(context.getString(R.string.app_name))
                 .setSmallIcon(R.drawable.ic_launcher)
                 .setAutoCancel(false)
                 .setOngoing(true)
-                .setContentIntent(PendingIntent.getBroadcast(context, 0, new Intent(context, ToggleRingPhone.class), PendingIntent.FLAG_UPDATE_CURRENT))
+                .setContentIntent(pi)
+                .setDeleteIntent(pi)
                 .build();
         notificationManager.notify(NOTIFICATION_ID, notification);
     }

--- a/app/src/main/res/menu/events.xml
+++ b/app/src/main/res/menu/events.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:tools="http://schemas.android.com/tools"
-      tools:context="net.sylvek.itracing2.dashboard.EventsHistoryFragment">
+    xmlns:tools="http://schemas.android.com/tools">
     <item
-            android:id="@+id/clear_events"
-            android:orderInCategory="100"
-            android:showAsAction="always"
-            android:icon="@android:drawable/ic_menu_delete"
-            android:title="@string/clear_events" tools:ignore="AppCompatResource"/>
+        android:id="@+id/clear_events"
+        android:icon="@android:drawable/ic_menu_delete"
+        android:orderInCategory="100"
+        android:showAsAction="always"
+        android:title="@string/clear_events"
+        tools:ignore="AppCompatResource" />
     <item
-            android:id="@+id/export_events"
-            android:orderInCategory="100"
-            android:showAsAction="always"
-            android:icon="@android:drawable/ic_menu_share"
-            android:title="@string/export_events" tools:ignore="AppCompatResource"/>
+        android:id="@+id/export_events"
+        android:icon="@android:drawable/ic_menu_share"
+        android:orderInCategory="100"
+        android:showAsAction="always"
+        android:title="@string/export_events"
+        tools:ignore="AppCompatResource" />
 </menu>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=--add-opens java.base/java.io=ALL-UNNAMED

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
With latest Android version, touching the stop ringer notification doesn't do it. It seems there is some problem with the intent which is created in `ToggleRingPhone::StartRing`. After a lot of experimentation, I tried setting the `ChannelId` and an explicit `ComponentName` which works. I have also added code to stop the ringer if the notification is dismissed, because otherwise there was no way to stop the ringer if you dismissed the notification by mistake.