### PR TITLE
Improve GPS handling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,10 +40,13 @@ repositories {
 }
 
 dependencies {
-    api 'com.android.support:appcompat-v7:23.1.1'
-    api 'com.android.support:support-v13:23.1.1'
-    api 'com.android.support:design:23.1.1'
-    api 'com.android.support:support-annotations:25.1.0'
+    //noinspection GradleCompatible,GradleCompatible
+    api 'com.android.support:appcompat-v7:28.0.0'
+    //noinspection GradleCompatible
+    api 'com.android.support:support-v13:28.0.0'
+    //noinspection GradleCompatible
+    api 'com.android.support:design:28.0.0'
+    api 'com.android.support:support-annotations:28.0.0'
     api 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.1.0'
 
     testImplementation 'junit:junit:4.12'

--- a/app/src/main/java/net/sylvek/itracing2/receivers/ToggleRingPhone.java
+++ b/app/src/main/java/net/sylvek/itracing2/receivers/ToggleRingPhone.java
@@ -4,6 +4,7 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.media.AudioManager;
@@ -32,6 +33,7 @@ public class ToggleRingPhone extends BroadcastReceiver {
     {
         // from notification
         if(intent.getAction() == null) {
+            Log.d(TAG,"null action");
             stopRing(context, intent);
             return;
         }
@@ -55,7 +57,7 @@ public class ToggleRingPhone extends BroadcastReceiver {
             stopRing(context, intent);
             return;
         }
-
+        Log.d(TAG,"unrecognised action");
     }
 
     private void startRing(Context context, Intent intent) {
@@ -78,16 +80,24 @@ public class ToggleRingPhone extends BroadcastReceiver {
         final int max = audioManager.getStreamMaxVolume(AudioManager.STREAM_RING);
         audioManager.setStreamVolume(AudioManager.STREAM_RING, max, 0);
 
+        currentRingtone.setLooping(true);
         currentRingtone.play();
+//        Intent stop = new Intent(context, ToggleRingPhone.class);
+        Intent stop = new Intent();
+        stop.setComponent(ComponentName.unflattenFromString("net.sylvek.itracing2.receivers.ToggleRingPhone"));
+        stop.setAction("net.sylvek.itracing2.action.STOP_RING_PHONE");
+        PendingIntent pi = PendingIntent.getBroadcast(context, 0, stop, PendingIntent.FLAG_UPDATE_CURRENT);
 
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        final Notification notification = new Notification.Builder(context)
+        final Notification notification = new Notification.Builder(context, "channel-itracing2")
+                .setChannelId("channel-itracing2")
                 .setContentText(context.getString(R.string.stop_ring))
                 .setContentTitle(context.getString(R.string.app_name))
                 .setSmallIcon(R.drawable.ic_launcher)
                 .setAutoCancel(false)
                 .setOngoing(true)
-                .setContentIntent(PendingIntent.getBroadcast(context, 0, new Intent(context, ToggleRingPhone.class), PendingIntent.FLAG_UPDATE_CURRENT))
+                .setContentIntent(pi)
+                .setDeleteIntent(pi)
                 .build();
         notificationManager.notify(NOTIFICATION_ID, notification);
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=--add-opens java.base/java.io=ALL-UNNAMED

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request forces the use of GPS if the device has it, and also replaces the deprecated call to `requestSingleUpdate`. In addition I have fixed the logic which added an event when the location was found and showed that location on the map if you clicked on that event.

Location permission should be requested when the user clicks on "capture my position" in an action preference list, because the user is interacting with program at that point, not as suggested in `CapturePosition` which may be happening in the background. This is bit tricky because the preferences are constructed by XML rather than by code, so it's hard to intercept the click. I'm looking into it.

I'm also looking at making the stop ringer action occur on a screen on event. This is a bit quicker than pulling down the notification and clicking on it. This change may appear in a future pull request, although it may be better to make it a selectable option in the global preferences.