### PR TITLE
Add action on Screen On

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # itracing2 
 
-[Available on F-Droid](https://f-droid.org/en/packages/net.sylvek.itracing2/) ❤️
+This version is forked from https://github.com/sylvek/itracing2
+
+Changes from sylvek/itracing2 are:
+
+* Updated to build and work with latest Android
+* Dismissing ringtone notification does the same thing as touching it (usually stop ringtone)
+* Added action on phone screen turned on (enables quick stop ringtone by pressing power-on button)
 
 ## History 📓
 itracing2 is a free and open source application allowing to manage "iTag" devices.
@@ -8,20 +14,20 @@ itracing2 is a free and open source application allowing to manage "iTag" device
 Around 2015, [Bluetooth LE](https://www.link-labs.com/blog/bluetooth-vs-bluetooth-low-energy) _(or Bluetooth 4)_ became popular on smartphones and a lot of gadget-keyring-bluetooth-brands rised from nowhere _(think about smart things)_.
 It was the begining of "IoT" for everyone and low cost devices from China invaded the market 😾 .
 
-Because "no name company" are only interested by selling devices, software were incredibly unusable.
+Because "no name company" are only interested by selling devices, software was closed source and incredibly unusable.
 
-Customers and myself were so disappointated that i decided to create my own application.
+Customers were so disappointated that Sylvain decided to create his own application.
 
-In 2021, [Apple released his AirTags](https://en.wikipedia.org/wiki/AirTag) 😮 . That's pretty smart because those devices are pretty cheap and by using iPhone/iPad as sensors, AirTags can be found anywhere in the Earth. Yes, every AirTags have an unique device id 👍 and i suppose that Apple knows who is the owner of a dedicated AirTag.
+In 2021, [Apple released his AirTags](https://en.wikipedia.org/wiki/AirTag) 😮 . That's pretty smart because those devices are pretty cheap and by using iPhone/iPad as sensors, AirTags can be found anywhere in the Earth. Yes, every AirTag has an unique device id and Apple probably knows who is the owner of a dedicated AirTag.
 
 ## Do you BLE? ⚙️
 
-If you want to learn more about BLE, there a lot of article on internet.
+If you want to learn more about BLE, there a lot of articles on the internet.
 - [A Practical Guide to BLE Throughput](https://interrupt.memfault.com/blog/ble-throughput-primer)
 - [List of Bluetooth profiles](https://en.wikipedia.org/wiki/List_of_Bluetooth_profiles)
 - [List of Service Class IDs](https://docs.microsoft.com/en-us/windows/uwp/devices-sensors/aep-service-class-ids)
 
-iTracing2 implementes ["Proximity Profile"](https://en.wikipedia.org/wiki/List_of_Bluetooth_profiles#Proximity_Profile_(PXP)) and should be compatible with a lot of devices.. **BUT** because [chinese iTag are so badly built](https://github.com/sylvek/itracing2/wiki/MLE-15), i hardcoded some stuff. _(prefer [Quintic PROXPR](https://github.com/sylvek/itracing2/wiki/Quintic-PROXR) chip if you can)_
+iTracing2 implementes ["Proximity Profile"](https://en.wikipedia.org/wiki/List_of_Bluetooth_profiles#Proximity_Profile_(PXP)) and should be compatible with a lot of devices.. **BUT** because [chinese iTag are so badly built](https://github.com/sylvek/itracing2/wiki/MLE-15), Sylvain hardcoded some stuff. _(prefer [Quintic PROXPR](https://github.com/sylvek/itracing2/wiki/Quintic-PROXR) chip if you can)_
 
 ## How that works?
 
@@ -29,12 +35,38 @@ iTracing2 implementes ["Proximity Profile"](https://en.wikipedia.org/wiki/List_o
 
 This application runs in background, so you do not have to launch it after each boot up.
 
-Several actions are available :
+For each iTag which has been attached to itracing2, you can configure itracing2 to take any of the following actions for any of the following events:
 
-* Capture your current position _(to work on Lineage OS, you need a Map application like OSMAnd or RMap)_
-* Ringing your phone
-* Vibrate your phone
-* Call a custom URL (`GET` action)
-* Call someone _(you need to explicitly give permission by navigating on permissions setting)_
+Actions:-
+
+* Capture your current position _(you need a Map application like OSMAnd or RMap or Organic Maps to display it)_
+* Start playing a ringtone on your phone
+* Stop playing the ringtone on your phone
+* Toggle the playing / not playing state of a ringtone on your phone
+* Start vibrating your phone
+* Stop vibrating your phone
+* Toggle the vibrating / not vibrating state of your phone
+* Capture current GPS position of your phone (_not_ the iTag)
 * Play/Pause audio playlist
-* And so one.. by [capturing custom event](https://github.com/sylvek/itracing2/wiki#custom-action) and plug [Tasker](https://github.com/sylvek/itracing2/wiki/Tasker)
+* call a custom Intent action (no extras possible - yet!)
+* Call a custom URL (`GET` action)
+* Call someone
+
+Events:-
+
+* Single click on the iTag's button
+* Double click on the iTag's button
+* iTag gets connected
+* iTag gets disconnected (powered off or out of range)
+* Phone screen on
+
+The ringtone can be specified for each combination of iTag and event. If you have a sound recorder, you can record a message for the phone to speak instead of a ringtone (might be useful if you tag your dog to make the phone call it to come back).
+
+Capturing the GPS position requires Location permission.
+Calling someone needs phone permission.
+
+Starting a ringtone creates a notification, and touching or dismissing the notification stops it again. Capturing the GPS position also creates a notification and touching the notification will bring up your mapping app (if you have one installed) with the captured GPS position as the target location. Touching a position event in the iTag's event history will also bring up your mapping app with the captured GPS position as the target location.
+
+If the iTag supports enabling and disabling the iTag beep when it loses the connection, you can change this setting from itracing2, but only while the iTag is connected. If you try to change it while the iTag is not conncted you get an error message. If the iTag doesn't support changing it, it just doesn't work (no error). If you don't need the beep, turning it off will improve iTag battery life.
+
+The range is about 100 metres outdoors and indoors reduces by about 20 meteres per intervening solid wall. If you put an iTag in your car and want to capture the GPS position where you parked it as soon as you get out of the car, put the iTag somewhere like under the spare wheel where there is a lot of metal around it to attenuate the signal and shorten the range.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,7 @@ android {
     defaultConfig {
         applicationId "net.sylvek.itracing2"
         minSdkVersion 22
+        //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 29
         versionCode 84
         versionName "2.5.9"
@@ -25,6 +26,14 @@ android {
         }
     }
     buildTypes {
+        debug {
+            debuggable true
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
+            jniDebuggable true
+            renderscriptDebuggable true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,10 +40,13 @@ repositories {
 }
 
 dependencies {
-    api 'com.android.support:appcompat-v7:23.1.1'
-    api 'com.android.support:support-v13:23.1.1'
-    api 'com.android.support:design:23.1.1'
-    api 'com.android.support:support-annotations:25.1.0'
+    //noinspection GradleCompatible,GradleCompatible
+    api 'com.android.support:appcompat-v7:28.0.0'
+    //noinspection GradleCompatible
+    api 'com.android.support:support-v13:28.0.0'
+    //noinspection GradleCompatible
+    api 'com.android.support:design:28.0.0'
+    api 'com.android.support:support-annotations:28.0.0'
     api 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.1.0'
 
     testImplementation 'junit:junit:4.12'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="net.sylvek.itracing2">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="net.sylvek.itracing2">
 
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
     <uses-feature android:name="android.hardware.location" android:required="false"/>
@@ -21,7 +22,8 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.DarkActionBar"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        tools:targetApi="m">
         <activity android:name=".devices.DevicesActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/app/src/main/java/net/sylvek/itracing2/BluetoothLEService.java
+++ b/app/src/main/java/net/sylvek/itracing2/BluetoothLEService.java
@@ -24,6 +24,7 @@ import net.sylvek.itracing2.receivers.CapturePosition;
 import net.sylvek.itracing2.receivers.CustomAction;
 import net.sylvek.itracing2.receivers.ImmediateAlert;
 import net.sylvek.itracing2.receivers.LinkBackground;
+import net.sylvek.itracing2.receivers.ScreenOn;
 import net.sylvek.itracing2.receivers.ToggleRingPhone;
 import net.sylvek.itracing2.receivers.ToggleVibratePhone;
 import net.sylvek.itracing2.receivers.TogglePlayPause;
@@ -347,6 +348,11 @@ public class BluetoothLEService extends Service {
         f7.addCategory("android.intent.category.DEFAULT");
         registerReceiver(new TogglePlayPause(), f7);
         Log.d(TAG, "TogglePlayPause() - registered with: " + f7);
+
+        IntentFilter f8 = new IntentFilter();
+        f8.addAction(Intent.ACTION_SCREEN_ON);
+        registerReceiver(new ScreenOn(), f8);
+        Log.d(TAG, "ScreenOn() - registered with: " + f8);
     }
 
     public void setForegroundEnabled(boolean enabled) {

--- a/app/src/main/java/net/sylvek/itracing2/BluetoothLEService.java
+++ b/app/src/main/java/net/sylvek/itracing2/BluetoothLEService.java
@@ -303,6 +303,7 @@ public class BluetoothLEService extends Service {
     private void registerReceivers() {
         IntentFilter f1 = new IntentFilter();
         f1.addAction("net.sylvek.itracing2.action.CAPTURE_POSITION");
+        f1.addAction("net.sylvek.itracing2.action.GOT_LOCATION");
         f1.addCategory("android.intent.category.DEFAULT");
         registerReceiver(new CapturePosition(), f1);
         Log.d(TAG, "CapturePosition() - registered with: " + f1);
@@ -370,10 +371,12 @@ public class BluetoothLEService extends Service {
     private String getNotificationChannel(NotificationManager notificationManager) {
         String channelId = "channel-itracing2";
         String channelName = getResources().getString(R.string.app_name);
-        NotificationChannel channel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH);
-        channel.setImportance(NotificationManager.IMPORTANCE_NONE);
-        channel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
-        notificationManager.createNotificationChannel(channel);
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            NotificationChannel channel =
+                    new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_NONE);
+            channel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
+            notificationManager.createNotificationChannel(channel);
+        }
         return channelId;
     }
 

--- a/app/src/main/java/net/sylvek/itracing2/Preferences.java
+++ b/app/src/main/java/net/sylvek/itracing2/Preferences.java
@@ -15,12 +15,13 @@ import android.preference.PreferenceManager;
 public class Preferences {
 
     public enum Source {
-        single_click, double_click, out_of_range, connected
+        single_click, double_click, out_of_range, connected, screen_on
     }
 
     public static final String ACTION_SIMPLE_BUTTON_LIST = "action_single_click_list";
     public static final String ACTION_DOUBLE_BUTTON_LIST = "action_double_click_list";
     public static final String ACTION_OUT_OF_RANGE_LIST = "action_out_of_range_list";
+    public static final String ACTION_SCREEN_ON_LIST = "action_screen_on_list";
     public static final String ACTION_CONNECTED_LIST = "action_connected_list";
     public static final String ACTION_ON_POWER_OFF = "action_on_power_off";
     public static final String RINGTONE = "ring_tone";
@@ -54,6 +55,9 @@ public class Preferences {
     {
         return getSharedPreferences(context, address).getStringSet(ACTION_OUT_OF_RANGE_LIST, Collections.<String>emptySet());
     }
+
+    public static Set<String> getActionScreenOn(Context context, String address) {
+        return getSharedPreferences(context, address).getStringSet(ACTION_SCREEN_ON_LIST, Collections.<String>emptySet());  }
 
     public static Set<String> getActionConnected(Context context, String address)
     {

--- a/app/src/main/java/net/sylvek/itracing2/receivers/CapturePosition.java
+++ b/app/src/main/java/net/sylvek/itracing2/receivers/CapturePosition.java
@@ -5,6 +5,7 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -13,72 +14,99 @@ import android.location.Location;
 import android.location.LocationManager;
 import android.net.Uri;
 import android.support.v4.app.ActivityCompat;
+import android.util.Log;
 
 import net.sylvek.itracing2.R;
 import net.sylvek.itracing2.database.Devices;
 import net.sylvek.itracing2.database.Events;
 
+import java.util.List;
+import java.util.Objects;
+
 /**
  * Created by sylvek on 12/06/2015.
  */
 public class CapturePosition extends BroadcastReceiver {
-
-    static final Criteria criteria = new Criteria();
+    private static Intent callback = new Intent();
 
     static final int NOTIFICATION_ID = 453436;
 
-    static final long MAX_AGE = 10000; // 10 seconds
     public static final String NAME = "position";
+    public static final String TAG = CapturePosition.class.toString();
+    static final String CALLBACKACTION = "net.sylvek.itracing2.action.GOT_LOCATION";
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        // because some customers don't like Google Play Services…
-        Location bestLocation = null;
-        final LocationManager locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-        assert locationManager != null;
-        for (final String provider : locationManager.getAllProviders()) {
+        final String action = intent.getAction();
+        final String name = intent.getStringExtra(Devices.NAME);
+        final String address = intent.getStringExtra(Devices.ADDRESS);
+        final LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+        callback.setComponent(ComponentName.unflattenFromString("net.sylvek.itracing2.receivers.CapturePosition"));
+        callback.setAction(CALLBACKACTION);
+        callback.putExtra(Devices.NAME, name);
+        callback.putExtra(Devices.ADDRESS, address);
+        PendingIntent pi = PendingIntent.getBroadcast(
+                context, 0, callback,
+                PendingIntent.FLAG_UPDATE_CURRENT);
+        if (Objects.equals(action, "net.sylvek.itracing2.action.CAPTURE_POSITION")) {
+            Log.d(TAG, "Capture position for " + name);
             if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                // TODO: Consider calling
-                //    ActivityCompat#requestPermissions
-                // here to request the missing permissions, and then overriding
-                //   public void onRequestPermissionsResult(int requestCode, String[] permissions,
-                //                                          int[] grantResults)
-                // to handle the case where the user grants the permission. See the documentation
-                // for ActivityCompat#requestPermissions for more details.
-                return;
+                // Location permission should be requested
+                // in the UI when user checks "capture my position"
+                // Hard to do because the logic is buried
+                // inside a MultiSelectListPreference.
             }
-            final Location location = locationManager.getLastKnownLocation(provider);
-            final long now = System.currentTimeMillis();
-            if (location != null
-                    && (bestLocation == null || location.getTime() > bestLocation.getTime())
-                    && location.getTime() > now - MAX_AGE) {
-                bestLocation = location;
+            List<String> ls = lm.getProviders(true);
+            try {
+                if (ls.contains("gps"))
+                {
+                    /* If GPS is available use GPS only. Other providers need
+                     * a Google server which has privacy and security issues.
+                     * Also the Google server relies on Google's list of locations
+                     * of cell towers and Wi-Fi hotspots, which are privately
+                     *  owned and can be moved, so Google's list can be out of date.
+                     */
+                    Log.d(TAG, "requestLocationUpdates from gps");
+                    lm.requestLocationUpdates(
+                            "gps", 0, 0, pi);
+                }
+                else
+                {
+                    // If we don't have GPS,
+                    // we use the best that the device can give us.
+                    Criteria cr = new Criteria();
+                    cr.setAccuracy(Criteria.ACCURACY_FINE);
+                    Log.d(TAG, "no gps, requestLocationUpdates from best available");
+                    lm.requestLocationUpdates(0, 0, cr, pi);
+                }
+            } catch (SecurityException e) {
+                Events.insert(context, "No location permission", address, "Please Allow Location permission in Settings");
+                Log.d(TAG, "No location permission");
             }
-        }
-
-        if (bestLocation == null) {
-            final PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-            locationManager.requestSingleUpdate(criteria, pendingIntent);
-        }
-
-        if (bestLocation != null) {
-            NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-            final String position = bestLocation.getLatitude() + "," + bestLocation.getLongitude();
-            final Intent mapIntent = getMapIntent(position);
-
-            final Notification notification = new Notification.Builder(context)
-                    .setChannelId("channel-itracing2")
-                    .setContentText(context.getString(R.string.display_last_position))
-                    .setContentTitle(context.getString(R.string.app_name))
-                    .setSmallIcon(R.drawable.ic_launcher)
-                    .setAutoCancel(false)
-                    .setContentIntent(PendingIntent.getActivity(context, 0, mapIntent, PendingIntent.FLAG_UPDATE_CURRENT))
-                    .build();
-            assert notificationManager != null;
-            notificationManager.notify(NOTIFICATION_ID, notification);
-
-            final String address = intent.getStringExtra(Devices.ADDRESS);
-            Events.insert(context, NAME, address, position);
+        } else if (Objects.equals(action, CALLBACKACTION)) {
+            Location here = intent.getParcelableExtra(
+                    LocationManager.KEY_LOCATION_CHANGED);
+            if (here != null) {
+                lm.removeUpdates(pi);
+                final String position = here.getLatitude() + "," + here.getLongitude();
+                Log.d(TAG, "got location " + position);
+                Events.insert(context, "position", address, position);
+                final Intent mapIntent = getMapIntent(position);
+                NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                final Notification.Builder nfb = new Notification.Builder(context);
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                    nfb.setChannelId("channel-itracing2");
+                }
+                nfb.setContentText(context.getString(R.string.display_last_position))
+                   .setContentTitle(context.getString(R.string.app_name))
+                   .setSmallIcon(R.drawable.ic_launcher)
+                   .setAutoCancel(false)
+                   .setContentIntent(PendingIntent.getActivity(context, 0, mapIntent, PendingIntent.FLAG_UPDATE_CURRENT));
+                notificationManager.notify(NOTIFICATION_ID, nfb.build());
+            } else {
+                // Otherwise we don't know what to do
+                Log.d(TAG, "CapturePosition bad action " + action);
+            }
         }
     }
 

--- a/app/src/main/java/net/sylvek/itracing2/receivers/ScreenOn.java
+++ b/app/src/main/java/net/sylvek/itracing2/receivers/ScreenOn.java
@@ -1,0 +1,38 @@
+package net.sylvek.itracing2.receivers;
+
+import static net.sylvek.itracing2.BluetoothLEService.TAG;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.util.Log;
+import net.sylvek.itracing2.Preferences;
+import net.sylvek.itracing2.database.Devices;
+import net.sylvek.itracing2.database.Events;
+
+public class ScreenOn extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent)
+    {
+        Log.d(TAG, "Screen on");
+        final Cursor cursor = Devices.findDevices(context);
+        if (cursor != null && cursor.getCount() > 0) {
+            cursor.moveToFirst();
+            do {
+                final String address = cursor.getString(0);
+                if (Devices.isEnabled(context, address)) {
+                    for (String action : Preferences.getActionScreenOn(context, address) {
+                        final Intent bi = new Intent("net.sylvek.itracing2.action." + action);
+                        bi.putExtra(Devices.ADDRESS, address);
+                        bi.putExtra(Devices.SOURCE, Preferences.Source.screen_on.name());
+                        bi.addCategory("android.intent.category.DEFAULT");
+                        context.sendBroadcast(bi);
+                        Events.insert(context, Preferences.Source.screen_on.name(), address, action);
+                    }
+                }
+            } while (cursor.moveToNext());
+        }
+    }
+}

--- a/app/src/main/java/net/sylvek/itracing2/receivers/ToggleRingPhone.java
+++ b/app/src/main/java/net/sylvek/itracing2/receivers/ToggleRingPhone.java
@@ -11,6 +11,7 @@ import android.media.AudioManager;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.Uri;
+import android.os.Build;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -80,26 +81,28 @@ public class ToggleRingPhone extends BroadcastReceiver {
         final int max = audioManager.getStreamMaxVolume(AudioManager.STREAM_RING);
         audioManager.setStreamVolume(AudioManager.STREAM_RING, max, 0);
 
-        currentRingtone.setLooping(true);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            currentRingtone.setLooping(true);
+        }
         currentRingtone.play();
 //        Intent stop = new Intent(context, ToggleRingPhone.class);
         Intent stop = new Intent();
         stop.setComponent(ComponentName.unflattenFromString("net.sylvek.itracing2.receivers.ToggleRingPhone"));
         stop.setAction("net.sylvek.itracing2.action.STOP_RING_PHONE");
         PendingIntent pi = PendingIntent.getBroadcast(context, 0, stop, PendingIntent.FLAG_UPDATE_CURRENT);
-
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        final Notification notification = new Notification.Builder(context, "channel-itracing2")
-                .setChannelId("channel-itracing2")
-                .setContentText(context.getString(R.string.stop_ring))
+        final Notification.Builder nfb = new Notification.Builder(context);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            nfb.setChannelId("channel-itracing2");
+        }
+        nfb.setContentText(context.getString(R.string.stop_ring))
                 .setContentTitle(context.getString(R.string.app_name))
                 .setSmallIcon(R.drawable.ic_launcher)
                 .setAutoCancel(false)
                 .setOngoing(true)
                 .setContentIntent(pi)
-                .setDeleteIntent(pi)
-                .build();
-        notificationManager.notify(NOTIFICATION_ID, notification);
+                .setDeleteIntent(pi);
+        notificationManager.notify(NOTIFICATION_ID, nfb.build());
     }
 
     private void stopRing(Context context, Intent intent) {

--- a/app/src/main/java/net/sylvek/itracing2/receivers/ToggleRingPhone.java
+++ b/app/src/main/java/net/sylvek/itracing2/receivers/ToggleRingPhone.java
@@ -4,6 +4,7 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.media.AudioManager;
@@ -32,6 +33,7 @@ public class ToggleRingPhone extends BroadcastReceiver {
     {
         // from notification
         if(intent.getAction() == null) {
+            Log.d(TAG,"null action");
             stopRing(context, intent);
             return;
         }
@@ -55,7 +57,7 @@ public class ToggleRingPhone extends BroadcastReceiver {
             stopRing(context, intent);
             return;
         }
-
+        Log.d(TAG,"unrecognised action");
     }
 
     private void startRing(Context context, Intent intent) {
@@ -78,16 +80,24 @@ public class ToggleRingPhone extends BroadcastReceiver {
         final int max = audioManager.getStreamMaxVolume(AudioManager.STREAM_RING);
         audioManager.setStreamVolume(AudioManager.STREAM_RING, max, 0);
 
+        currentRingtone.setLooping(true);
         currentRingtone.play();
+//        Intent stop = new Intent(context, ToggleRingPhone.class);
+        Intent stop = new Intent();
+        stop.setComponent(ComponentName.unflattenFromString("net.sylvek.itracing2.receivers.ToggleRingPhone"));
+        stop.setAction("net.sylvek.itracing2.action.STOP_RING_PHONE");
+        PendingIntent pi = PendingIntent.getBroadcast(context, 0, stop, PendingIntent.FLAG_UPDATE_CURRENT);
 
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        final Notification notification = new Notification.Builder(context)
+        final Notification notification = new Notification.Builder(context, "channel-itracing2")
+                .setChannelId("channel-itracing2")
                 .setContentText(context.getString(R.string.stop_ring))
                 .setContentTitle(context.getString(R.string.app_name))
                 .setSmallIcon(R.drawable.ic_launcher)
                 .setAutoCancel(false)
                 .setOngoing(true)
-                .setContentIntent(PendingIntent.getBroadcast(context, 0, new Intent(context, ToggleRingPhone.class), PendingIntent.FLAG_UPDATE_CURRENT))
+                .setContentIntent(pi)
+                .setDeleteIntent(pi)
                 .build();
         notificationManager.notify(NOTIFICATION_ID, notification);
     }

--- a/app/src/main/res/menu/events.xml
+++ b/app/src/main/res/menu/events.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:tools="http://schemas.android.com/tools"
-      tools:context="net.sylvek.itracing2.dashboard.EventsHistoryFragment">
+    xmlns:tools="http://schemas.android.com/tools">
     <item
-            android:id="@+id/clear_events"
-            android:orderInCategory="100"
-            android:showAsAction="always"
-            android:icon="@android:drawable/ic_menu_delete"
-            android:title="@string/clear_events" tools:ignore="AppCompatResource"/>
+        android:id="@+id/clear_events"
+        android:icon="@android:drawable/ic_menu_delete"
+        android:orderInCategory="100"
+        android:showAsAction="always"
+        android:title="@string/clear_events"
+        tools:ignore="AppCompatResource" />
     <item
-            android:id="@+id/export_events"
-            android:orderInCategory="100"
-            android:showAsAction="always"
-            android:icon="@android:drawable/ic_menu_share"
-            android:title="@string/export_events" tools:ignore="AppCompatResource"/>
+        android:id="@+id/export_events"
+        android:icon="@android:drawable/ic_menu_share"
+        android:orderInCategory="100"
+        android:showAsAction="always"
+        android:title="@string/export_events"
+        tools:ignore="AppCompatResource" />
 </menu>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -72,6 +72,7 @@
         <item>start vibrate the phone</item>
         <item>stop vibrate the phone</item>
         <item>capture my position</item>
+        <item>toggle AudioManager Play/Pause</item>
         <item>call a url or broadcast intent action</item>
     </string-array>
     <string-array name="button_actions_values">
@@ -82,7 +83,8 @@
         <item>START_VIBRATE_PHONE</item>
         <item>STOP_VIBRATE_PHONE</item>
         <item>CAPTURE_POSITION</item>
-        <item>CUSTOM_ACTION</item>
+         <item>TOGGLE_PLAY_PAUSE</item>
+       <item>CUSTOM_ACTION</item>
     </string-array>
     <string-array name="empty_array"/>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -66,6 +66,7 @@
         <item>Starte Vibration des Telefons</item>
         <item>Stoppe Vibration des Telefons</item>
         <item>Meine Position erfassen</item>
+        <item>toggle AudioManager Play/Pause</item>
         <item>Eine URL oder einen broadcast intent aufrufen</item>
     </string-array>
     <string-array name="button_actions_values">
@@ -76,6 +77,7 @@
         <item>START_VIBRATE_PHONE</item>
         <item>STOP_VIBRATE_PHONE</item>
         <item>CAPTURE_POSITION</item>
+        <item>TOGGLE_PLAY_PAUSE</item>
         <item>CUSTOM_ACTION</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -72,6 +72,7 @@
         <item>Activar vibración</item>
         <item>Detener vibración</item>
         <item>Capturar mi posición</item>
+        <item>toggle AudioManager Play/Pause</item>
         <item>Activar url o acción</item>
     </string-array>
     <string-array name="button_actions_values">
@@ -82,6 +83,7 @@
         <item>START_VIBRATE_PHONE</item>
         <item>STOP_VIBRATE_PHONE</item>
         <item>CAPTURE_POSITION</item>
+        <item>TOGGLE_PLAY_PAUSE</item>
         <item>CUSTOM_ACTION</item>
     </string-array>
     <string-array name="empty_array"/>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -68,6 +68,7 @@
         <item>faire vibrer le téléphone</item>
         <item>arrêter les vibrations</item>
         <item>capturer ma position</item>
+        <item>toggle AudioManager Play/Pause</item>
         <item>appeler une URL ou une action</item>
     </string-array>
     <string-array name="button_actions_values">
@@ -78,6 +79,7 @@
         <item>START_VIBRATE_PHONE</item>
         <item>STOP_VIBRATE_PHONE</item>
         <item>CAPTURE_POSITION</item>
+        <item>TOGGLE_PLAY_PAUSE</item>
         <item>CUSTOM_ACTION</item>
     </string-array>
     <string-array name="empty_array"/>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -82,6 +82,7 @@
         <item>START_VIBRATE_PHONE</item>
         <item>STOP_VIBRATE_PHONE</item>
         <item>CAPTURE_POSITION</item>
+        <item>toggle AudioManager Play/Pause</item>
         <item>CUSTOM_ACTION</item>
     </string-array>
     <string-array name="button_actions">
@@ -92,6 +93,7 @@
         <item>Vibra indít</item>
         <item>Vibra állj</item>
         <item>Helymeghatározás</item>
+        <item>TOGGLE_PLAY_PAUSE</item>
         <item>url vagy intent meghívása</item>
     </string-array>
     <string name="stop_ring">Csengés állj</string> <!-- notification -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -73,6 +73,7 @@
         <item>Laat de telefoon trillen</item>
         <item>Stop het trillen van de telefoon</item>
         <item>Sla mijn positie op</item>
+        <item>toggle AudioManager Play/Pause</item>
         <item>Open een URL of start een actie</item>
     </string-array>
     <string-array name="button_actions_values">
@@ -83,6 +84,7 @@
         <item>START_VIBRATE_PHONE</item>
         <item>STOP_VIBRATE_PHONE</item>
         <item>CAPTURE_POSITION</item>
+        <item>TOGGLE_PLAY_PAUSE</item>
         <item>CUSTOM_ACTION</item>
     </string-array>
     <string-array name="empty_array"/>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -72,6 +72,7 @@
         <item>вибрация в телефоне</item>
         <item>остановить вибрации</item>
         <item>сохранить мою позицию</item>
+        <item>toggle AudioManager Play/Pause</item>
         <item>открыть URL или другое действие</item>
     </string-array>
     <string-array name="button_actions_values">
@@ -82,6 +83,7 @@
         <item>START_VIBRATE_PHONE</item>
         <item>STOP_VIBRATE_PHONE</item>
         <item>CAPTURE_POSITION</item>
+        <item>TOGGLE_PLAY_PAUSE</item>
         <item>CUSTOM_ACTION</item>
     </string-array>
     <string-array name="empty_array"/>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -72,6 +72,7 @@
         <item>telefonu titret</item>
         <item>titreşimi durdur</item>
         <item>konumumu kaydet</item>
+        <item>toggle AudioManager Play/Pause</item>
         <item>bir url yada aksiyon metni çağır</item>
     </string-array>
     <string-array name="button_actions_values">
@@ -82,6 +83,7 @@
         <item>START_VIBRATE_PHONE</item>
         <item>STOP_VIBRATE_PHONE</item>
         <item>CAPTURE_POSITION</item>
+        <item>TOGGLE_PLAY_PAUSE</item>
         <item>CUSTOM_ACTION</item>
     </string-array>
     <string-array name="empty_array"/>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -72,6 +72,7 @@
         <item>вібрація в телефоні</item>
         <item>зупинити вібрацію</item>
         <item>зберегти координати</item>
+        <item>toggle AudioManager Play/Pause</item>
         <item>відкрити URL чи прибити москаля</item>
     </string-array>
     <string-array name="button_actions_values">
@@ -82,6 +83,7 @@
         <item>START_VIBRATE_PHONE</item>
         <item>STOP_VIBRATE_PHONE</item>
         <item>CAPTURE_POSITION</item>
+        <item>TOGGLE_PLAY_PAUSE</item>
         <item>CUSTOM_ACTION</item>
     </string-array>
     <string-array name="empty_array"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">iTracing2</string>
     <string name="ble_not_supported">sorry bluetooth LE is not supported on your device</string>
     <string name="action_scan_start">detect</string>
@@ -31,6 +31,8 @@
     <string name="display_last_position">display the last recorded position</string>
     <string name="out_of_range_action">out of range action</string>
     <string name="out_of_range_action_summary">triggered when disconnection occurs</string>
+    <string name="screen_on_action">screen on action</string>
+    <string name="screen_on_action_summary">triggered when phone screen on</string>
     <string name="action_on_power_off">link is lost on power off</string>
     <string name="action_on_power_off_summary">the link is lost if keyring or bluetooth is powering off</string>
     <string name="action_bip_out_of_range">iTag beep</string>

--- a/app/src/main/res/xml/device_preferences.xml
+++ b/app/src/main/res/xml/device_preferences.xml
@@ -53,28 +53,45 @@
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/out_of_range_action">
         <MultiSelectListPreference
-                android:key="action_out_of_range_list"
-                android:title="@string/out_of_range_action"
-                android:summary="@string/out_of_range_action_summary"
-                android:entries="@array/button_actions"
-                android:entryValues="@array/button_actions_values"
-                android:defaultValue="@array/empty_array"/>
+            android:key="action_out_of_range_list"
+            android:title="@string/out_of_range_action"
+            android:summary="@string/out_of_range_action_summary"
+            android:entries="@array/button_actions"
+            android:entryValues="@array/button_actions_values"
+            android:defaultValue="@array/empty_array"/>
         <CheckBoxPreference
-                android:key="action_itracing_bip_out_of_range"
-                android:title="@string/action_bip_out_of_range"
-                android:summary="@string/action_bip_out_of_range_summary"
-                android:defaultValue="true"/>
+            android:key="action_itracing_bip_out_of_range"
+            android:title="@string/action_bip_out_of_range"
+            android:summary="@string/action_bip_out_of_range_summary"
+            android:defaultValue="true"/>
         <CheckBoxPreference
-                android:key="action_on_power_off"
-                android:title="@string/action_on_power_off"
-                android:summary="@string/action_on_power_off_summary"/>
+            android:key="action_on_power_off"
+            android:title="@string/action_on_power_off"
+            android:summary="@string/action_on_power_off_summary"/>
         <Preference
-                android:title="@string/ring_tone"
-                android:summary="@string/ring_tone_summary"
-                android:key="ring_tone_out_of_range"/>
+            android:title="@string/ring_tone"
+            android:summary="@string/ring_tone_summary"
+            android:key="ring_tone_out_of_range"/>
         <EditTextPreference
-                android:title="@string/custom_action"
-                android:summary="@string/custom_action_summary"
-                android:key="custom_action_out_of_range"/>
+            android:title="@string/custom_action"
+            android:summary="@string/custom_action_summary"
+            android:key="custom_action_out_of_range"/>
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/screen_on_action">
+        <MultiSelectListPreference
+            android:key="action_screen_on_list"
+            android:title="@string/screen_on_action"
+            android:summary="@string/screen_on_action_summary"
+            android:entries="@array/button_actions"
+            android:entryValues="@array/button_actions_values"
+            android:defaultValue="@array/empty_array"/>
+        <Preference
+            android:title="@string/ring_tone"
+            android:summary="@string/ring_tone_summary"
+            android:key="ring_tone_out_of_range"/>
+        <EditTextPreference
+            android:title="@string/custom_action"
+            android:summary="@string/custom_action_summary"
+            android:key="custom_action_screen_on"/>
     </PreferenceCategory>
 </PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=--add-opens java.base/java.io=ALL-UNNAMED

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This change adds the ability to specify an action applied to all enabled devices when the phone becomes interactive. Basically this is equivalent to turning on the screen with older phones, but with some modern phones which support an always-on screen, the screen on action is taken when the user switches from the always-on default display to the home screen.

The intention of this change is to enable a quick switch off of a ringer if you have deliberately gone out leaving a tagged object behind at home. Simply specify the action on Screen On to be stop the ringer.